### PR TITLE
fix rlbench success conditions for close jar task

### DIFF
--- a/rlbench/tasks/close_jar.py
+++ b/rlbench/tasks/close_jar.py
@@ -39,8 +39,9 @@ class CloseJar(Task):
         self.jars[index % 2].set_color(target_color_rgb)
         other_index = {0: 1, 1: 0}
         self.jars[other_index[index % 2]].set_color(distractor_color_rgb)
-        self.conditions += [DetectedCondition(self.lid, success)]
-        self.register_success_conditions(self.conditions)
+        self.register_success_conditions([DetectedCondition(self.lid, success)])
+        #self.conditions += [DetectedCondition(self.lid, success)]
+        #self.register_success_conditions(self.conditions)
         return ['close the %s jar' % target_color_name,
                 'screw on the %s jar lid' % target_color_name,
                 'grasping the lid, lift it from the table and use it to seal '


### PR DESCRIPTION
The success condition in this RLBench branch is malfunctioned.  Replaying the [provided demonstrations](https://github.com/peract/peract#quickstart) results in a 0% success rate. The issue can be addressed in this commit, which includes a one-line fix for the problem.